### PR TITLE
Fix artifact hub ID for chart

### DIFF
--- a/charts/regauth/artifacthub-repo.yml
+++ b/charts/regauth/artifacthub-repo.yml
@@ -1,4 +1,4 @@
-repositoryID: 6fea405b-1c23-4e26-8454-7d3495c269bc
+repositoryID: 47531a96-3eb0-47b6-bd76-5c23ac12cce1
 owners:
   - name: evanebb
     email: git@evanus.nl


### PR DESCRIPTION
I used the wrong repository type first on Artifact Hub, oops